### PR TITLE
Fix server proxy setter to return true

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ node_js:
   - "6"
   - "7"
   - "8"
+  - "10"
 script: npm run coveralls

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -168,6 +168,7 @@ class Server {
 const handler = {
     set(server, name, handlerFunction) {
         server.regsiterHandler(name, handlerFunction);
+        return true;
     },
 
     get(server, name) {


### PR DESCRIPTION
According to the [specification](http://www.ecma-international.org/ecma-262/6.0/#sec-set-o-p-v-throw) proxy setter must return `true` if operation was successful. I'm not sure if all Node versions follow the spec, but in 10.6 I cannot add handlers to the server: `TypeError: 'set' on proxy: trap returned falsish for property 'myMethod'`. This fixes it…