### PR TITLE
support more request params in client

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,12 @@ try {
 
 #### Client
 
-| Option            | Default       | Description                         |
-| ----------------- | ------------- | ----------------------------------- |
-| `host`            | `"127.0.0.1"` | The host that the server listens on |
-| `port`            | `6356`        | The port that the server listens on |
-| `connectTimeout`  | `0`           | The socket connection timeout       |
-| `responseTimeout` | `0`           | The response wait timeout           |
+| Option            | Default                     | Description                         |
+| ----------------- | --------------------------- | ----------------------------------- |
+| `host`            | `"127.0.0.1"`               | The host that the server listens on |
+| `port`            | `6356`                      | The port that the server listens on |
+| `headers`         | `{ 'X-Api-Key': 'secret' }` | Additional request headers          |
+| `connectTimeout`  | `0`                         | The socket connection timeout       |
+| `responseTimeout` | `0`                         | The response wait timeout           |
 
-Client's constructor also supports options from [http.request()](https://nodejs.org/api/http.html#http_http_request_options_callback). For example, you can set `headers` to add extra headers to http request, or `auth` if you need Basic Authentication. You cannot change _http method_ or `Content-Type` header.
+`createClient` also supports options from [http.request()](https://nodejs.org/api/http.html#http_http_request_options_callback). For example, you can set `headers` to add extra headers to http request, or `auth` if you need Basic Authentication. You cannot change http request _method_.

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ try {
 
 | Option            | Default                     | Description                         |
 | ----------------- | --------------------------- | ----------------------------------- |
-| `host`            | `"127.0.0.1"`               | The host that the server listens on |
-| `port`            | `6356`                      | The port that the server listens on |
-| `headers`         | `{ 'X-Api-Key': 'secret' }` | Additional request headers          |
-| `connectTimeout`  | `0`                         | The socket connection timeout       |
-| `responseTimeout` | `0`                         | The response wait timeout           |
+| `host`            | `"127.0.0.1"` | The host that the server listens on |
+| `port`            | `6356`        | The port that the server listens on |
+| `headers`         | `{}`          | Additional request headers          |
+| `connectTimeout`  | `0`           | The socket connection timeout       |
+| `responseTimeout` | `0`           | The response wait timeout           |
 
 `createClient` also supports options from [http.request()](https://nodejs.org/api/http.html#http_http_request_options_callback). For example, you can set `headers` to add extra headers to http request, or `auth` if you need Basic Authentication. You cannot change http request _method_.

--- a/README.md
+++ b/README.md
@@ -60,8 +60,11 @@ try {
 
 #### Client
 
-| Option    | Default       | Description                        |
-| --------- | ------------- | ---------------------------------- |
-| `host`    | `"127.0.0.1"` | The host that the server listen on |
-| `port`    | `6356`        | The port that the server listen on |
-| `timeout` | `0`           | The request timeout                |
+| Option            | Default       | Description                         |
+| ----------------- | ------------- | ----------------------------------- |
+| `host`            | `"127.0.0.1"` | The host that the server listens on |
+| `port`            | `6356`        | The port that the server listens on |
+| `connectTimeout`  | `0`           | The socket connection timeout       |
+| `responseTimeout` | `0`           | The response wait timeout           |
+
+Client's constructor also supports options from [http.request()](https://nodejs.org/api/http.html#http_http_request_options_callback). For example, you can set `headers` to add extra headers to http request, or `auth` if you need Basic Authentication. You cannot change _http method_ or `Content-Type` header.

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -13,7 +13,7 @@ const defaultOptions = {
 class Client {
     constructor(userOptions) {
         this.options = Object.assign({}, defaultOptions, userOptions || {});
-        this.options.headers = Object.assign({}, this.options.headers || {}, { 'Content-Type': 'application/json' });
+        this.options.headers = Object.assign({ 'Content-Type': 'application/json' }, this.options.headers || {});
         this.options.method = 'POST';
         if (this.options.timeout != null) {
             this.options.responseTimeout = this.options.timeout;

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -140,7 +140,7 @@ class Server {
         return object;
     }
 
-    // Convert the data to the format that will be sent backt to the client
+    // Convert the data to the format that will be sent back to the client
     createRPCObject(data) {
         if (data instanceof Error) {
             return {
@@ -156,7 +156,7 @@ class Server {
         return { jsonrpc: '2.0', result: data.result, id: data.id };
     }
 
-    regsiterHandler(name, handler) {
+    registerHandler(name, handler) {
         this.handlers[name] = handler;
     }
 
@@ -167,7 +167,7 @@ class Server {
 
 const handler = {
     set(server, name, handlerFunction) {
-        server.regsiterHandler(name, handlerFunction);
+        server.registerHandler(name, handlerFunction);
         return true;
     },
 

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -1,5 +1,5 @@
 const chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz'.split('');
-function gererateID() {
+function generateID() {
     let str = '';
     for (let i = 0; i < 16; i += 1) {
         str += chars[Math.floor(Math.random() * chars.length)];
@@ -13,4 +13,4 @@ function validateRequest(data) {
     );
 }
 
-module.exports = { gererateID, validateRequest };
+module.exports = { generateID, validateRequest };


### PR DESCRIPTION
Hello, me again. :) I needed to add extra parameters to http requests in RPC client:

* http basic auth
* setting `X-Api-Key` header on request
* using custom ssl certificated in https agent

Instead of making many little patches, I made this one to expose all available http.request() options at once.

I also used this opportunity to make some little fixes: typo in utils method name, merging all chunks at once at the end, so less memory allocations and also `options` object is created once for all requests. I also made sure to keep backwards compatibility with code that uses `timeout` option.