### PR TITLE
accept falsy results in the client

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -64,9 +64,9 @@ class Client {
     }
 
     finishRequest(data) {
-        if (data.result) {
+        if (data && 'result' in data) {
             return data.result;
-        } else if (data.error) {
+        } else if (data && data.error) {
             const error = new Error(data.error.message);
             if (data.error.data) {
                 Object.assign(error, data.error.data);


### PR DESCRIPTION
I had a problem with remote server returning `null` as a valid response. As far as I can see, returning `false`, `0` or empty string would produce the same result, since the value is implicitly cast as Boolean to check its presence. With this patch client accepts any present result value as long as `result` key is present in the response object…